### PR TITLE
feat(viz): display tree disc (if available)

### DIFF
--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -82,6 +82,8 @@ export const getServerSideProps: GetServerSideProps<
 
 const InfoList: FC<{
   treeData: TreeDataType | null
+  treeDataIsLoading: boolean
+  treeDataError: Error | null
   nowcastData: MappedNowcastRowsType | null
   nowcastIsLoading: boolean
   nowcastError: Error | null
@@ -91,7 +93,14 @@ const InfoList: FC<{
   shadingData: useShadingDataReturnType['data']
   shadingIsLoading: useShadingDataReturnType['isLoading']
   shadingError: useShadingDataReturnType['error']
-}> = ({ treeData, rainData, rainIsLoading, shadingData, shadingIsLoading }) => {
+}> = ({
+  treeData,
+  treeDataIsLoading,
+  rainData,
+  rainIsLoading,
+  shadingData,
+  shadingIsLoading,
+}) => {
   const { t } = useTranslation('common')
 
   const shadingValue = shadingData && shadingData * 100 // original shadingData is between 0 - 1
@@ -143,22 +152,22 @@ const InfoList: FC<{
           />
         }
       />
-      <DataListItem
-        title={t(`treeView.infoList.treeDisc.label`)}
-        subtitle={t(`treeView.infoList.treeDisc.hint`)}
-        datavisIcon={
-          <DatavisIcon
-            iconType="square"
-            // TODO: [QTREES-447] Remove dummy data for treeDisc
-            // Update when adding access to real data.
-            iconValue={normalizeValue(3.1, [0, 10])}
-            valueLabel={t(`treeView.infoList.treeDisc.value`, {
-              value: 3.1,
-            })}
-          />
-        }
-      />
-      {treeData?.stammumfg && (
+      {!treeDataIsLoading && treeData?.baumscheibe && (
+        <DataListItem
+          title={t(`treeView.infoList.treeDisc.label`)}
+          subtitle={t(`treeView.infoList.treeDisc.hint`)}
+          datavisIcon={
+            <DatavisIcon
+              iconType="square"
+              iconValue={normalizeValue(treeData?.baumscheibe, [0, 10])}
+              valueLabel={t(`treeView.infoList.treeDisc.value`, {
+                value: treeData?.baumscheibe,
+              })}
+            />
+          }
+        />
+      )}
+      {!treeDataIsLoading && treeData?.stammumfg && (
         <DataListItem
           title={t(`treeView.infoList.trunkCircumference.label`)}
           subtitle={t(`treeView.infoList.trunkCircumference.hint`)}
@@ -349,6 +358,8 @@ const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
                 content: (
                   <InfoList
                     treeData={treeData}
+                    treeDataIsLoading={treeDataLoading}
+                    treeDataError={treeDataError}
                     nowcastData={nowcastData}
                     nowcastError={nowcastError}
                     nowcastIsLoading={nowcastIsLoading}

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -80,6 +80,8 @@ export const getServerSideProps: GetServerSideProps<
   }
 }
 
+const NoDataIndicator: FC = () => <span>–</span>
+
 const InfoList: FC<{
   treeData: TreeDataType | null
   treeDataIsLoading: boolean
@@ -103,15 +105,18 @@ const InfoList: FC<{
 }) => {
   const { t } = useTranslation('common')
 
-  const shadingValue = shadingData && shadingData * 100 // original shadingData is between 0 - 1
+  // Original shadingData is between 0 - 1, so we multiply by 100:
+  const shadingValue = !shadingIsLoading && shadingData && shadingData * 100
+  const rainValue = !rainIsLoading && rainData
+  const treeDiscValue = !treeDataIsLoading && treeData?.baumscheibe
 
   return (
     <ul className="relative z-10 bg-white">
-      {shadingValue && !shadingIsLoading && (
-        <DataListItem
-          title={t(`treeView.infoList.shading.label`)}
-          subtitle={t(`treeView.infoList.shading.hint`)}
-          datavisIcon={
+      <DataListItem
+        title={t(`treeView.infoList.shading.label`)}
+        subtitle={t(`treeView.infoList.shading.hint`)}
+        datavisIcon={
+          shadingValue ? (
             <DatavisIcon
               iconType="clock"
               iconValue={normalizeValue(shadingValue, [0, 100])}
@@ -119,24 +124,28 @@ const InfoList: FC<{
                 value: shadingValue.toFixed(0),
               })}
             />
-          }
-        />
-      )}
-      {rainData && !rainIsLoading && (
-        <DataListItem
-          title={t(`treeView.infoList.rainAmount.label`)}
-          subtitle={t(`treeView.infoList.rainAmount.hint`)}
-          datavisIcon={
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
+      <DataListItem
+        title={t(`treeView.infoList.rainAmount.label`)}
+        subtitle={t(`treeView.infoList.rainAmount.hint`)}
+        datavisIcon={
+          rainValue ? (
             <DatavisIcon
               iconType="water-drops"
-              iconValue={normalizeValue(Number(rainData?.toFixed(1)), [0, 500])}
+              iconValue={normalizeValue(rainValue, [0, 500])}
               valueLabel={t(`treeView.infoList.rainAmount.value`, {
-                value: rainData?.toFixed(1),
+                value: rainValue.toFixed(1),
               })}
             />
-          }
-        />
-      )}
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
       <DataListItem
         title={t(`treeView.infoList.wateringAmount.label`)}
         subtitle={t(`treeView.infoList.wateringAmount.hint`)}
@@ -152,21 +161,23 @@ const InfoList: FC<{
           />
         }
       />
-      {!treeDataIsLoading && treeData?.baumscheibe && (
-        <DataListItem
-          title={t(`treeView.infoList.treeDisc.label`)}
-          subtitle={t(`treeView.infoList.treeDisc.hint`)}
-          datavisIcon={
+      <DataListItem
+        title={t(`treeView.infoList.treeDisc.label`)}
+        subtitle={t(`treeView.infoList.treeDisc.hint`)}
+        datavisIcon={
+          treeDiscValue ? (
             <DatavisIcon
               iconType="square"
-              iconValue={normalizeValue(treeData?.baumscheibe, [0, 10])}
+              iconValue={normalizeValue(treeDiscValue, [0, 10])}
               valueLabel={t(`treeView.infoList.treeDisc.value`, {
                 value: treeData?.baumscheibe,
               })}
             />
-          }
-        />
-      )}
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
       {!treeDataIsLoading && treeData?.stammumfg && (
         <DataListItem
           title={t(`treeView.infoList.trunkCircumference.label`)}

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -109,6 +109,7 @@ const InfoList: FC<{
   const shadingValue = !shadingIsLoading && shadingData && shadingData * 100
   const rainValue = !rainIsLoading && rainData
   const treeDiscValue = !treeDataIsLoading && treeData?.baumscheibe
+  const trunkCircumferenceValue = !treeDataIsLoading && treeData?.stammumfg
 
   return (
     <ul className="relative z-10 bg-white">
@@ -178,21 +179,23 @@ const InfoList: FC<{
           )
         }
       />
-      {!treeDataIsLoading && treeData?.stammumfg && (
-        <DataListItem
-          title={t(`treeView.infoList.trunkCircumference.label`)}
-          subtitle={t(`treeView.infoList.trunkCircumference.hint`)}
-          datavisIcon={
+      <DataListItem
+        title={t(`treeView.infoList.trunkCircumference.label`)}
+        subtitle={t(`treeView.infoList.trunkCircumference.hint`)}
+        datavisIcon={
+          trunkCircumferenceValue ? (
             <DatavisIcon
               iconType="circle"
-              iconValue={normalizeValue(treeData.stammumfg, [0, 800])}
+              iconValue={normalizeValue(trunkCircumferenceValue, [0, 800])}
               valueLabel={t(`treeView.infoList.trunkCircumference.value`, {
-                value: treeData.stammumfg,
+                value: trunkCircumferenceValue,
               })}
             />
-          }
-        />
-      )}
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
     </ul>
   )
 }

--- a/src/components/TreeInfoHeader/index.tsx
+++ b/src/components/TreeInfoHeader/index.tsx
@@ -4,14 +4,15 @@ import {
   Plant as PlantIcon,
 } from '@components/Icons'
 import { TreeContextMenu } from '@components/TreeContextMenu'
+import { TreeDataType } from '@lib/requests/getTreeData'
 import classNames from 'classnames'
 import useTranslation from 'next-translate/useTranslation'
 import { FC } from 'react'
 
 export interface TreeInfoHeaderType {
   species: string
-  height?: number | string
-  age?: number | string
+  height?: TreeDataType['baumhoehe']
+  age?: TreeDataType['standalter']
   statusBackgroundColor?: string
   statusBorderColor?: string
   isCompressed?: boolean

--- a/src/components/TreesMap/index.tsx
+++ b/src/components/TreesMap/index.tsx
@@ -25,6 +25,7 @@ import {
   NEXT_PUBLIC_MAPTILER_BASEMAP_URL,
   NEXT_PUBLIC_MAPTILER_KEY,
 } from '@lib/utils/envUtil'
+import { TreeDataType } from '@lib/requests/getTreeData'
 
 interface OnSelectOutput {
   id: string
@@ -44,8 +45,8 @@ interface MapProps {
   }
   mapId: string
   mapStyle?: string
-  latitude?: number
-  longitude?: number
+  latitude?: TreeDataType['lat']
+  longitude?: TreeDataType['lng']
   treeIdToSelect?: string
   onSelect?: (treeData: OnSelectOutput) => void
   onOutdatedNowcastChange?: (isOutdated: boolean) => void

--- a/src/lib/requests/getTreeData.ts
+++ b/src/lib/requests/getTreeData.ts
@@ -1,42 +1,7 @@
+import { Database } from '@lib/types/database'
 import { getBaseUrl } from '@lib/utils/urlUtil'
 
-/**
- * According to the database schema all values except id are nullable.
- * The id is what is the tree_id in the nowcast table.
- */
-export type TreeDataType = {
-  id: string
-  treeId?: string
-  standortnr?: string
-  kennzeich?: string
-  namenr?: string
-  /** Genus in German  */
-  art_dtsch?: string
-  /** Botanical genus  */
-  art_bot?: string
-  gattung_deutsch?: string
-  hausnr?: string
-  strname?: string
-  pflanzjahr?: number
-  standalter?: number
-  /** Circumference of the tree trunk  */
-  stammumfg?: number
-  baumhoehe?: number
-  bezirk?: string
-  eigentuemer?: string
-  zusatz?: string
-  /** Diameter of the treetop  */
-  kronedurch?: number
-  /** `geometry` is actually a PostGIS Point type but we receive it already parsed. */
-  geometry?: {
-    type: 'Point'
-    coordinates: [number, number]
-  }
-  lat?: number
-  lng?: number
-  created_at?: string
-  updated_at?: string
-}
+export type TreeDataType = Database['public']['Tables']['trees']['Row']
 
 const TABLE_NAME = 'trees'
 /** The API requires the search param to be the `id` column */

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -374,6 +374,7 @@ export interface Database {
           art_bot: string | null
           art_dtsch: string | null
           baumhoehe: number | null
+          baumscheibe: number | null
           bezirk: string | null
           created_at: string | null
           eigentuemer: string | null


### PR DESCRIPTION
This PR adds access to the real tree disc data which is now available in the DB at `trees.baumscheibe`.

All values are currently `NULL` which means that no real data for the tree discs can be displayed.