### PR TITLE
feat(gdk): Adds api route to lookup trees in GDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ NEXT_PUBLIC_MATOMO_URL="https://piwik.technologiestiftung-berlin.de"
 NEXT_PUBLIC_MATOMO_SITE_ID="13"
 NEXT_PUBLIC_BASE_URL="https://localhost:3000"
 
+# for requests to the giessdenkiez.de API
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+SUPABASE_API_URL=http://localhost:54321
 # postgrest credentials for the ml database by the birds
 ML_PGREST_PORT=3000
 ML_PGREST_PASSWORD=qfpqowefkwwefwelfwepf

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ NEXT_PUBLIC_MATOMO_SITE_ID="13"
 NEXT_PUBLIC_BASE_URL="https://localhost:3000"
 
 # for requests to the giessdenkiez.de API
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-SUPABASE_API_URL=http://localhost:54321
+SUPABASE_GDK_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+SUPABASE_GDK_API_URL=http://localhost:54321
 # postgrest credentials for the ml database by the birds
 ML_PGREST_PORT=3000
 ML_PGREST_PASSWORD=qfpqowefkwwefwelfwepf

--- a/pages/api/trees/gdk.ts
+++ b/pages/api/trees/gdk.ts
@@ -1,0 +1,77 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY
+const SUPABASE_API_URL = process.env.SUPABASE_API_URL
+/**
+ * Small wrapper to fetch the primary key id
+ * from the giessdenkiez.de database API by looking it up
+ * based on the gmlid used in qtree.
+ * Used to create a link in the UI to direct users to the right tree
+ * in the giessdenkiez.de.
+ *
+ * FInal link in giessdenkiez.de looks like this:
+ * `https://www.giessdenkiez.de/tree/_1234567`
+ * @example
+ * fetch('/api/trees/gdk?gmlid=00008100:000be766')
+ * // returns { data: { id: "_1234567", gmlid: '00008100:000be766' } }
+ * @example
+ * $ curl "http://localhost:3000/api/trees/gdk?gmlid=00008100:000be766"
+ * > { "data": { "id": "_1234567", "gmlid": "00008100:000be766" } }
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (!SUPABASE_ANON_KEY) {
+    const error = new Error('env var SUPABASE_ANON_KEY is missing')
+    console.error(error)
+    return res.status(500).json({ error })
+  }
+  if (!SUPABASE_API_URL) {
+    const error = new Error('env var SUPABASE_API_URL is missing')
+    console.error(error)
+    return res.status(500).json({ error })
+  }
+  if (req.url === undefined) {
+    const error = new Error('url is missing on req')
+    console.error(error)
+    return res.status(500).json({ error })
+  }
+  const url = new URL(
+    req.url,
+    `http://${req.headers.host ? req.headers.host : 'localhost'}`
+  )
+
+  const { searchParams } = url
+  if (!searchParams.has('gmlid')) {
+    return res.status(400).json({ error: 'Missing gmlid search parameter' })
+  }
+  switch (req.method) {
+    case 'GET': {
+      const response = await fetch(
+        `${SUPABASE_API_URL}/rest/v1/trees?gmlid=eq.${
+          searchParams.get('gmlid') as string
+        }&select=id,gmlid`,
+        {
+          method: 'GET',
+          headers: {
+            apikey: SUPABASE_ANON_KEY,
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+      if (!response.ok) {
+        const err = await response.text()
+        return res.status(500).json({ error: `internal server error. ${err}` })
+      }
+      const data = (await response.json()) as Record<string, unknown>
+      if (!data) {
+        return res.status(500).json({ error: 'internal server error' })
+      }
+      return res.status(200).json({ data })
+    }
+    default: {
+      return res.status(404).json({ error: 'only GET method allowed' })
+    }
+  }
+}

--- a/pages/api/trees/gdk.ts
+++ b/pages/api/trees/gdk.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY
-const SUPABASE_API_URL = process.env.SUPABASE_API_URL
+const SUPABASE_GDK_ANON_KEY = process.env.SUPABASE_GDK_ANON_KEY
+const SUPABASE_GDK_API_URL = process.env.SUPABASE_GDK_API_URL
 /**
  * Small wrapper to fetch the primary key id
  * from the giessdenkiez.de database API by looking it up
@@ -13,21 +13,21 @@ const SUPABASE_API_URL = process.env.SUPABASE_API_URL
  * `https://www.giessdenkiez.de/tree/_1234567`
  * @example
  * fetch('/api/trees/gdk?gmlid=00008100:000be766')
- * // returns { data: { id: "_1234567", gmlid: '00008100:000be766' } }
+ * // returns { data: [{ id: "_1234567", gmlid: '00008100:000be766' }] }
  * @example
  * $ curl "http://localhost:3000/api/trees/gdk?gmlid=00008100:000be766"
- * > { "data": { "id": "_1234567", "gmlid": "00008100:000be766" } }
+ * > { "data": [{ "id": "_1234567", "gmlid": "00008100:000be766" }] }
  */
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
-  if (!SUPABASE_ANON_KEY) {
+  if (!SUPABASE_GDK_ANON_KEY) {
     const error = new Error('env var SUPABASE_ANON_KEY is missing')
     console.error(error)
     return res.status(500).json({ error })
   }
-  if (!SUPABASE_API_URL) {
+  if (!SUPABASE_GDK_API_URL) {
     const error = new Error('env var SUPABASE_API_URL is missing')
     console.error(error)
     return res.status(500).json({ error })
@@ -49,13 +49,13 @@ export default async function handler(
   switch (req.method) {
     case 'GET': {
       const response = await fetch(
-        `${SUPABASE_API_URL}/rest/v1/trees?gmlid=eq.${
+        `${SUPABASE_GDK_API_URL}/rest/v1/trees?gmlid=eq.${
           searchParams.get('gmlid') as string
         }&select=id,gmlid`,
         {
           method: 'GET',
           headers: {
-            apikey: SUPABASE_ANON_KEY,
+            apikey: SUPABASE_GDK_ANON_KEY,
             'Content-Type': 'application/json',
           },
         }


### PR DESCRIPTION
Small wrapper to fetch the primary key id from the giessdenkiez.de database API by looking it up based on the gmlid used in qtree. Used to create a link in the UI to direct users to the right tree in the giessdenkiez.de.
Final link in giessdenkiez.de looks like this: `https://www.giessdenkiez.de/tree/_1234567`

example: 

```js
 fetch('/api/trees/gdk?gmlid=00008100:000be766')
 // returns { data: [{ id: "_1234567", gmlid: '00008100:000be766' }] }
```

example: 

```bash
 $ curl "http://localhost:3000/api/trees/gdk?gmlid=00008100:000be766"
 > { "data": [{ "id": "_1234567", "gmlid": "00008100:000be766" }] }
```
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203712922731739