### PR TITLE
feat: display watering data

### DIFF
--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -135,7 +135,7 @@
       },
       "rainAmount": {
         "label": "Niederschlagsmenge",
-        "hint": "Letzte 14 Tage",
+        "hint": "In den letzten 14 Tagen",
         "value": "{{value}} l/qm"
       },
       "treeDisc": {
@@ -150,7 +150,7 @@
       },
       "wateringAmount": {
         "label": "Gießwassermenge",
-        "hint": "Letzte 60 Tage",
+        "hint": "In den letzten 60 Tagen",
         "value": "{{value}} l"
       },
       "trunkCircumference": {

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -150,7 +150,7 @@
       },
       "wateringAmount": {
         "label": "Gießwassermenge",
-        "hint": "Letzte 14 Tage",
+        "hint": "Letzte 60 Tage",
         "value": "{{value}} l"
       },
       "trunkCircumference": {

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -34,6 +34,10 @@ import {
   useShadingData,
   useShadingDataReturnType,
 } from '@lib/hooks/useShadingData'
+import {
+  useWateringData,
+  useWateringDataReturnType,
+} from '@lib/hooks/useWateringData'
 
 interface TreePageComponentPropType {
   treeId: TreeDataType['id']
@@ -96,6 +100,9 @@ const InfoList: FC<{
   shadingData: useShadingDataReturnType['data']
   shadingIsLoading: useShadingDataReturnType['isLoading']
   shadingError: useShadingDataReturnType['error']
+  wateringData: useWateringDataReturnType['data']
+  wateringDataIsLoading: useWateringDataReturnType['isLoading']
+  wateringDataError: useWateringDataReturnType['error']
 }> = ({
   treeData,
   treeDataIsLoading,
@@ -103,6 +110,8 @@ const InfoList: FC<{
   rainIsLoading,
   shadingData,
   shadingIsLoading,
+  wateringData,
+  wateringDataIsLoading,
 }) => {
   const { t } = useTranslation('common')
 
@@ -111,6 +120,7 @@ const InfoList: FC<{
   const rainValue = !rainIsLoading && rainData
   const treeDiscValue = !treeDataIsLoading && treeData?.baumscheibe
   const trunkCircumferenceValue = !treeDataIsLoading && treeData?.stammumfg
+  const wateringValue = !wateringDataIsLoading && wateringData
 
   return (
     <ul className="relative z-10 bg-white">
@@ -154,15 +164,19 @@ const InfoList: FC<{
         title={t(`treeView.infoList.wateringAmount.label`)}
         subtitle={t(`treeView.infoList.wateringAmount.hint`)}
         datavisIcon={
-          <DatavisIcon
-            iconType="water-drops"
-            // TODO: [QTREES-449] Remove dummy data for wateringAmount
-            // Update when adding access to real data.
-            iconValue={Math.round(normalizeValue(25, [0, 500], [0, 5]))}
-            valueLabel={t(`treeView.infoList.wateringAmount.value`, {
-              value: 25,
-            })}
-          />
+          wateringValue ? (
+            <DatavisIcon
+              iconType="water-drops"
+              iconValue={Math.round(
+                normalizeValue(wateringValue, [0, 500], [0, 5])
+              )}
+              valueLabel={t(`treeView.infoList.wateringAmount.value`, {
+                value: wateringValue.toFixed(),
+              })}
+            />
+          ) : (
+            <NoDataIndicator />
+          )
         }
       />
       <DataListItem
@@ -238,6 +252,12 @@ const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
     error: rainError,
     isLoading: rainIsLoading,
   } = useTreeRainAmount(treeData?.id)
+
+  const {
+    data: wateringData,
+    error: wateringDataError,
+    isLoading: wateringDataIsLoading,
+  } = useWateringData(treeData?.id, csrfToken)
 
   if (treeDataError) {
     void push('/404')
@@ -392,6 +412,9 @@ const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
                     shadingData={shadingData}
                     shadingError={shadingError}
                     shadingIsLoading={shadingIsLoading}
+                    wateringData={wateringData}
+                    wateringDataError={wateringDataError}
+                    wateringDataIsLoading={wateringDataIsLoading}
                   />
                 ),
               },

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -1,11 +1,10 @@
-import { FC, ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { MapLayout } from '@layouts/MapLayout'
 import classNames from 'classnames'
 import { GetServerSideProps, NextPage } from 'next'
 import { TreeDataType } from '@lib/requests/getTreeData'
 import { useNowcastData } from '@lib/hooks/useNowcastData'
 import { TreeInfoHeader } from '@components/TreeInfoHeader'
-import { DataListItem } from '@components/DataListItem'
 import { mapSuctionTensionToStatus } from '@lib/utils/mapSuctionTensionToStatus'
 import { GroundLayersViz } from '@components/GroundLayersViz'
 import { useRouter } from 'next/router'
@@ -22,22 +21,13 @@ import csrf from '@lib/api/csrf'
 import { useForecastData } from '@lib/hooks/useForecastData'
 import { combineNowAndForecastData } from '@lib/utils/forecastUtil/forecastUtil'
 import { useTreeRainAmount } from '@lib/hooks/useTreeRainAmount'
-import { TreeRainAmountType } from '@lib/requests/getTreeRainAmount'
-import { MappedNowcastRowsType } from '@lib/utils/mapRowsToDepths'
 import { useTreeData } from '@lib/hooks/useTreeData'
 import { mapRawQueryToState } from '@lib/utils/queryUtil'
 import { Head } from '@components/Head'
-import { DatavisIcon } from '@components/DatavisIcons/DatavisIcon'
-import { normalizeValue } from '@lib/utils/normalizeValue'
 import { ParkTreeHint } from '@components/ParkTreeHint'
-import {
-  useShadingData,
-  useShadingDataReturnType,
-} from '@lib/hooks/useShadingData'
-import {
-  useWateringData,
-  useWateringDataReturnType,
-} from '@lib/hooks/useWateringData'
+import { useShadingData } from '@lib/hooks/useShadingData'
+import { useWateringData } from '@lib/hooks/useWateringData'
+import { TreeInfoList } from '@components/TreeInfoList'
 
 interface TreePageComponentPropType {
   treeId: TreeDataType['id']
@@ -83,138 +73,6 @@ export const getServerSideProps: GetServerSideProps<
       notFound: true,
     }
   }
-}
-
-const NoDataIndicator: FC = () => <span>–</span>
-
-const InfoList: FC<{
-  treeData: TreeDataType | null
-  treeDataIsLoading: boolean
-  treeDataError: Error | null
-  nowcastData: MappedNowcastRowsType | null
-  nowcastIsLoading: boolean
-  nowcastError: Error | null
-  rainData: TreeRainAmountType | null
-  rainIsLoading: boolean
-  rainError: Error | null
-  shadingData: useShadingDataReturnType['data']
-  shadingIsLoading: useShadingDataReturnType['isLoading']
-  shadingError: useShadingDataReturnType['error']
-  wateringData: useWateringDataReturnType['data']
-  wateringDataIsLoading: useWateringDataReturnType['isLoading']
-  wateringDataError: useWateringDataReturnType['error']
-}> = ({
-  treeData,
-  treeDataIsLoading,
-  rainData,
-  rainIsLoading,
-  shadingData,
-  shadingIsLoading,
-  wateringData,
-  wateringDataIsLoading,
-}) => {
-  const { t } = useTranslation('common')
-
-  // Original shadingData is between 0 - 1, so we multiply by 100:
-  const shadingValue = !shadingIsLoading && shadingData && shadingData * 100
-  const rainValue = !rainIsLoading && rainData
-  const treeDiscValue = !treeDataIsLoading && treeData?.baumscheibe
-  const trunkCircumferenceValue = !treeDataIsLoading && treeData?.stammumfg
-  const wateringValue = !wateringDataIsLoading && wateringData
-
-  return (
-    <ul className="relative z-10 bg-white">
-      <DataListItem
-        title={t(`treeView.infoList.shading.label`)}
-        subtitle={t(`treeView.infoList.shading.hint`)}
-        datavisIcon={
-          shadingValue ? (
-            <DatavisIcon
-              iconType="clock"
-              iconValue={normalizeValue(shadingValue, [0, 100])}
-              valueLabel={t(`treeView.infoList.shading.value`, {
-                value: shadingValue.toFixed(0),
-              })}
-            />
-          ) : (
-            <NoDataIndicator />
-          )
-        }
-      />
-      <DataListItem
-        title={t(`treeView.infoList.rainAmount.label`)}
-        subtitle={t(`treeView.infoList.rainAmount.hint`)}
-        datavisIcon={
-          rainValue ? (
-            <DatavisIcon
-              iconType="water-drops"
-              iconValue={Math.round(
-                normalizeValue(rainValue, [0, 500], [0, 5])
-              )}
-              valueLabel={t(`treeView.infoList.rainAmount.value`, {
-                value: rainValue.toFixed(1),
-              })}
-            />
-          ) : (
-            <NoDataIndicator />
-          )
-        }
-      />
-      <DataListItem
-        title={t(`treeView.infoList.wateringAmount.label`)}
-        subtitle={t(`treeView.infoList.wateringAmount.hint`)}
-        datavisIcon={
-          wateringValue ? (
-            <DatavisIcon
-              iconType="water-drops"
-              iconValue={Math.round(
-                normalizeValue(wateringValue, [0, 500], [0, 5])
-              )}
-              valueLabel={t(`treeView.infoList.wateringAmount.value`, {
-                value: wateringValue.toFixed(),
-              })}
-            />
-          ) : (
-            <NoDataIndicator />
-          )
-        }
-      />
-      <DataListItem
-        title={t(`treeView.infoList.treeDisc.label`)}
-        subtitle={t(`treeView.infoList.treeDisc.hint`)}
-        datavisIcon={
-          treeDiscValue ? (
-            <DatavisIcon
-              iconType="square"
-              iconValue={normalizeValue(treeDiscValue, [0, 10])}
-              valueLabel={t(`treeView.infoList.treeDisc.value`, {
-                value: treeData?.baumscheibe,
-              })}
-            />
-          ) : (
-            <NoDataIndicator />
-          )
-        }
-      />
-      <DataListItem
-        title={t(`treeView.infoList.trunkCircumference.label`)}
-        subtitle={t(`treeView.infoList.trunkCircumference.hint`)}
-        datavisIcon={
-          trunkCircumferenceValue ? (
-            <DatavisIcon
-              iconType="circle"
-              iconValue={normalizeValue(trunkCircumferenceValue, [0, 800])}
-              valueLabel={t(`treeView.infoList.trunkCircumference.value`, {
-                value: trunkCircumferenceValue,
-              })}
-            />
-          ) : (
-            <NoDataIndicator />
-          )
-        }
-      />
-    </ul>
-  )
 }
 
 const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
@@ -399,7 +257,7 @@ const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
               {
                 name: t('treeView.tabs.0'),
                 content: (
-                  <InfoList
+                  <TreeInfoList
                     treeData={treeData}
                     treeDataIsLoading={treeDataLoading}
                     treeDataError={treeDataError}

--- a/src/components/TreeInfoList/index.tsx
+++ b/src/components/TreeInfoList/index.tsx
@@ -1,0 +1,144 @@
+import { DataListItem } from '@components/DataListItem'
+import { DatavisIcon } from '@components/DatavisIcons/DatavisIcon'
+import { useShadingDataReturnType } from '@lib/hooks/useShadingData'
+import { useWateringDataReturnType } from '@lib/hooks/useWateringData'
+import { TreeDataType } from '@lib/requests/getTreeData'
+import { TreeRainAmountType } from '@lib/requests/getTreeRainAmount'
+import { MappedNowcastRowsType } from '@lib/utils/mapRowsToDepths'
+import { normalizeValue } from '@lib/utils/normalizeValue'
+import useTranslation from 'next-translate/useTranslation'
+import { FC } from 'react'
+
+const NoDataIndicator: FC = () => <span>–</span>
+
+interface TreeInfoListType {
+  treeData: TreeDataType | null
+  treeDataIsLoading: boolean
+  treeDataError: Error | null
+  nowcastData: MappedNowcastRowsType | null
+  nowcastIsLoading: boolean
+  nowcastError: Error | null
+  rainData: TreeRainAmountType | null
+  rainIsLoading: boolean
+  rainError: Error | null
+  shadingData: useShadingDataReturnType['data']
+  shadingIsLoading: useShadingDataReturnType['isLoading']
+  shadingError: useShadingDataReturnType['error']
+  wateringData: useWateringDataReturnType['data']
+  wateringDataIsLoading: useWateringDataReturnType['isLoading']
+  wateringDataError: useWateringDataReturnType['error']
+}
+
+export const TreeInfoList: FC<TreeInfoListType> = ({
+  treeData,
+  treeDataIsLoading,
+  rainData,
+  rainIsLoading,
+  shadingData,
+  shadingIsLoading,
+  wateringData,
+  wateringDataIsLoading,
+}) => {
+  const { t } = useTranslation('common')
+
+  // Original shadingData is between 0 - 1, so we multiply by 100:
+  const shadingValue = !shadingIsLoading && shadingData && shadingData * 100
+  const rainValue = !rainIsLoading && rainData
+  const treeDiscValue = !treeDataIsLoading && treeData?.baumscheibe
+  const trunkCircumferenceValue = !treeDataIsLoading && treeData?.stammumfg
+  const wateringValue = !wateringDataIsLoading && wateringData
+
+  return (
+    <ul className="relative z-10 bg-white">
+      <DataListItem
+        title={t(`treeView.infoList.shading.label`)}
+        subtitle={t(`treeView.infoList.shading.hint`)}
+        datavisIcon={
+          shadingValue ? (
+            <DatavisIcon
+              iconType="clock"
+              iconValue={normalizeValue(shadingValue, [0, 100])}
+              valueLabel={t(`treeView.infoList.shading.value`, {
+                value: shadingValue.toFixed(0),
+              })}
+            />
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
+      <DataListItem
+        title={t(`treeView.infoList.rainAmount.label`)}
+        subtitle={t(`treeView.infoList.rainAmount.hint`)}
+        datavisIcon={
+          rainValue ? (
+            <DatavisIcon
+              iconType="water-drops"
+              iconValue={Math.round(
+                normalizeValue(rainValue, [0, 500], [0, 5])
+              )}
+              valueLabel={t(`treeView.infoList.rainAmount.value`, {
+                value: rainValue.toFixed(1),
+              })}
+            />
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
+      <DataListItem
+        title={t(`treeView.infoList.wateringAmount.label`)}
+        subtitle={t(`treeView.infoList.wateringAmount.hint`)}
+        datavisIcon={
+          wateringValue ? (
+            <DatavisIcon
+              iconType="water-drops"
+              iconValue={Math.round(
+                normalizeValue(wateringValue, [0, 500], [0, 5])
+              )}
+              valueLabel={t(`treeView.infoList.wateringAmount.value`, {
+                value: wateringValue.toFixed(),
+              })}
+            />
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
+      <DataListItem
+        title={t(`treeView.infoList.treeDisc.label`)}
+        subtitle={t(`treeView.infoList.treeDisc.hint`)}
+        datavisIcon={
+          treeDiscValue ? (
+            <DatavisIcon
+              iconType="square"
+              iconValue={normalizeValue(treeDiscValue, [0, 10])}
+              valueLabel={t(`treeView.infoList.treeDisc.value`, {
+                value: treeData?.baumscheibe,
+              })}
+            />
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
+      <DataListItem
+        title={t(`treeView.infoList.trunkCircumference.label`)}
+        subtitle={t(`treeView.infoList.trunkCircumference.hint`)}
+        datavisIcon={
+          trunkCircumferenceValue ? (
+            <DatavisIcon
+              iconType="circle"
+              iconValue={normalizeValue(trunkCircumferenceValue, [0, 800])}
+              valueLabel={t(`treeView.infoList.trunkCircumference.value`, {
+                value: trunkCircumferenceValue,
+              })}
+            />
+          ) : (
+            <NoDataIndicator />
+          )
+        }
+      />
+    </ul>
+  )
+}

--- a/src/components/TreeInfoList/index.tsx
+++ b/src/components/TreeInfoList/index.tsx
@@ -9,7 +9,9 @@ import { normalizeValue } from '@lib/utils/normalizeValue'
 import useTranslation from 'next-translate/useTranslation'
 import { FC } from 'react'
 
-const NoDataIndicator: FC = () => <span>–</span>
+const NoDataIndicator: FC = () => (
+  <hr className="w-4 h-px border border-gray-600 translate-y-4" />
+)
 
 interface TreeInfoListType {
   treeData: TreeDataType | null

--- a/src/components/TreeInfoList/index.tsx
+++ b/src/components/TreeInfoList/index.tsx
@@ -77,7 +77,7 @@ export const TreeInfoList: FC<TreeInfoListType> = ({
             <DatavisIcon
               iconType="water-drops"
               iconValue={Math.round(
-                normalizeValue(rainValue, [0, 500], [0, 5])
+                normalizeValue(rainValue, [0, 250], [0, 5])
               )}
               valueLabel={t(`treeView.infoList.rainAmount.value`, {
                 value: rainValue.toFixed(1),
@@ -96,7 +96,7 @@ export const TreeInfoList: FC<TreeInfoListType> = ({
             <DatavisIcon
               iconType="water-drops"
               iconValue={Math.round(
-                normalizeValue(wateringValue, [0, 500], [0, 5])
+                normalizeValue(wateringValue, [0, 250], [0, 5])
               )}
               valueLabel={t(`treeView.infoList.wateringAmount.value`, {
                 value: wateringValue.toFixed(),

--- a/src/lib/hooks/useWateringData/index.ts
+++ b/src/lib/hooks/useWateringData/index.ts
@@ -1,0 +1,24 @@
+import { getWateringValue } from '@lib/requests/getWateringValue'
+import useSWR from 'swr'
+
+export interface useWateringDataReturnType {
+  isLoading: boolean
+  data: number | null
+  error: Error | null
+}
+
+export const useWateringData = (
+  treeId: string | undefined,
+  csrfToken: string
+): useWateringDataReturnType => {
+  const params = [`Watering - Tree ID - ${treeId || 'nodata'}`]
+  const { data, error } = useSWR<number | undefined, Error>(params, () =>
+    treeId ? getWateringValue(treeId, csrfToken) : undefined
+  )
+
+  return {
+    isLoading: !data && !error,
+    data: data || null,
+    error: error || null,
+  }
+}

--- a/src/lib/requests/getShading.ts
+++ b/src/lib/requests/getShading.ts
@@ -10,6 +10,7 @@ export type ShadingType = Database['public']['Tables']['shading']['Row']
 /**
  * Fetches the current shading data for a tree.
  * @param treeId string
+ * @param csrfToken string
  * @returns Promise<number | undefined>
  */
 export const getShading = async (

--- a/src/lib/requests/getWateringValue/index.ts
+++ b/src/lib/requests/getWateringValue/index.ts
@@ -1,0 +1,60 @@
+import { getBaseUrl } from '@lib/utils/urlUtil'
+
+const VIEW_NAME = 'watering'
+const TREE_ID_COLUMN_NAME = 'tree_id'
+
+// Note that we have to define this type ourselves because the type generator
+// is currently not able to type database views.
+interface WateringType {
+  tree_id: string
+  sum: number
+  date: Date
+}
+
+/**
+ * Fetches the watering value in liters for a tree.
+ * Currently this fetches the waterings of the past 60 days.
+ * @param treeId string
+ * @param csrfToken string
+ * @returns number | undefined
+ */
+export const getWateringValue = async (
+  treeId: string,
+  csrfToken: string
+): Promise<number | undefined> => {
+  if (!treeId) return
+
+  const REQUEST_URL = `${getBaseUrl()}/api/ml-api-passthrough/${VIEW_NAME}`
+
+  const REQUEST_PARAMS = new URLSearchParams({
+    [TREE_ID_COLUMN_NAME]: `eq.${treeId}`,
+  })
+
+  const response = await fetch(`${REQUEST_URL}?${REQUEST_PARAMS.toString()}`, {
+    method: 'POST',
+    headers: {
+      'CSRF-Token': csrfToken,
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    const txt = await response.text()
+    console.error(txt)
+    throw new Error(txt)
+  }
+
+  const { data: waterings } = (await response.json()) as {
+    data: WateringType[]
+  }
+
+  if (!waterings || waterings.length === 0) return
+
+  const wateringValue = waterings
+    .map((watering) => watering.sum)
+    .reduce((accumulator, currentValue) => {
+      return accumulator + currentValue
+    })
+
+  return wateringValue
+}


### PR DESCRIPTION
This PR displays the watering value for a tree if it exists. If not it falls back to a no-data-indicator. The watering value is fetched from a view in the database that combines the values from Gieß den Kiez waterings and official waterings, both of which from **the last 60 days**. That date check is done in the database view, so it is not needed in the frontend anymore.

---

Currently there is watering data only for a small fraction of trees (in the staging DB). Try e.g. tree `00008100:001557cd` for an existent watering value.