### PR TITLE
fix: average nowcast

### DIFF
--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -132,9 +132,10 @@ const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
   }
 
   const avgLevel =
-    nowcastData && nowcastData.depthAverageRow?.value
-      ? mapSuctionTensionToStatus(nowcastData.depthAverageRow?.value)?.id
+    nowcastData && nowcastData.averageNowcastValue
+      ? mapSuctionTensionToStatus(nowcastData.averageNowcastValue)?.id
       : undefined
+
   const circleColorClasses = getClassesByStatusId(avgLevel)
 
   const nowcastReady = forecastData && forecastData?.length > 0

--- a/src/lib/utils/mapRowsToDepths/mapRowsToDepths.test.ts
+++ b/src/lib/utils/mapRowsToDepths/mapRowsToDepths.test.ts
@@ -16,33 +16,62 @@ describe('mapRowsToDepths', () => {
         id: 41729,
         type_id: 3,
       },
-      {
-        id: 15292,
-        type_id: 4,
-      },
     ]
     const mappedRows = mapRowsToDepths(ROWS_WITH_COMPLETE_DATA)
     expect(mappedRows.depth30Row).toHaveProperty('type_id', 1)
     expect(mappedRows.depth60Row).toHaveProperty('type_id', 2)
     expect(mappedRows.depth90Row).toHaveProperty('type_id', 3)
-    expect(mappedRows.depthAverageRow).toHaveProperty('type_id', 4)
+  })
+  test('calculates average from latest rows with type_id 1, 2, or 3', () => {
+    const EARLIEST_TIMESTAMP = '2022-08-21T11:00:00.000Z'
+    const LATEST_TIMESTAMP = '2022-08-21T12:00:00.000Z'
+
+    // From this rows we want the average of 2, 4, and 6. We mix in an older datum for type_id 3 and a row for type_id 4 to make sure that we calculate the average from the desired rows.
+    const ROWS_WITH_MESSY_DATA: NowcastDataType[] = [
+      {
+        id: 35223,
+        type_id: 1,
+        value: 2,
+      },
+      {
+        id: 89262,
+        type_id: 2,
+        value: 4,
+      },
+      {
+        id: 546292,
+        type_id: 3,
+        value: 1000,
+        timestamp: EARLIEST_TIMESTAMP,
+      },
+      {
+        id: 41729,
+        type_id: 3,
+        value: 6,
+        timestamp: LATEST_TIMESTAMP,
+      },
+      {
+        id: 15292,
+        type_id: 4,
+        value: 1,
+      },
+    ]
+    const mappedRows = mapRowsToDepths(ROWS_WITH_MESSY_DATA)
+    expect(mappedRows.averageNowcastValue).toEqual(4)
   })
   test('maps only the rows that match', () => {
     const ROWS_WITH_COMPLETE_DATA: NowcastDataType[] = [
       {
         id: 35223,
         type_id: 1,
-      },
-      {
-        id: 15292,
-        type_id: 4,
+        value: 10,
       },
     ]
     const mappedRows = mapRowsToDepths(ROWS_WITH_COMPLETE_DATA)
     expect(mappedRows.depth30Row).toHaveProperty('type_id', 1)
     expect(mappedRows.depth60Row).toBeUndefined()
     expect(mappedRows.depth90Row).toBeUndefined()
-    expect(mappedRows.depthAverageRow).toHaveProperty('type_id', 4)
+    expect(mappedRows.averageNowcastValue).toEqual(10)
   })
   test('uses the latest timestamp if there are duplicates', () => {
     const EARLIEST_TIMESTAMP = '2022-08-21T11:00:00.000Z'
@@ -72,6 +101,5 @@ describe('mapRowsToDepths', () => {
     expect(mappedRows.depth60Row).toHaveProperty('type_id', 2)
     expect(mappedRows.depth60Row).toHaveProperty('timestamp', LATEST_TIMESTAMP)
     expect(mappedRows.depth90Row).toBeUndefined()
-    expect(mappedRows.depthAverageRow).toBeUndefined()
   })
 })

--- a/src/lib/utils/mapRowsToDepths/mapRowsToDepths.ts
+++ b/src/lib/utils/mapRowsToDepths/mapRowsToDepths.ts
@@ -4,11 +4,11 @@ export interface MappedNowcastRowsType {
   depth30Row: NowcastDataType | undefined
   depth60Row: NowcastDataType | undefined
   depth90Row: NowcastDataType | undefined
-  depthAverageRow: NowcastDataType | undefined
+  averageNowcastValue: number | undefined
 }
 
 /**
- * Maps raw nowcast rows to named fields according to their type (type_id 1 -> -30cm, type_id 2 -> 60cm, type_id 3 -> 90cm, type_id 4 -> average)
+ * Maps raw nowcast rows to named fields according to their type (type_id 1 -> -30cm, type_id 2 -> 60cm, type_id 3 -> 90cm). Also returns the average nowcast value for these rows.
  * @param nowcastRows NowcastDataType[]
  * @returns MappedNowcastRowsType
  */
@@ -24,10 +24,25 @@ export const mapRowsToDepths = (
     }
     return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   })
+
+  const depth30Row = descendingRows.find((row) => row.type_id === 1)
+  const depth60Row = descendingRows.find((row) => row.type_id === 2)
+  const depth90Row = descendingRows.find((row) => row.type_id === 3)
+
+  const foundRows = [depth30Row, depth60Row, depth90Row].filter(
+    Boolean
+  ) as NowcastDataType[]
+
+  const sumOfValues = (accumulator: number, obj: NowcastDataType): number =>
+    accumulator + (obj?.value || 0)
+
+  const averageNowcastValue =
+    foundRows.reduce(sumOfValues, 0) / foundRows.length
+
   return {
-    depth30Row: descendingRows.find((row) => row.type_id === 1),
-    depth60Row: descendingRows.find((row) => row.type_id === 2),
-    depth90Row: descendingRows.find((row) => row.type_id === 3),
-    depthAverageRow: descendingRows.find((row) => row.type_id === 4),
+    depth30Row,
+    depth60Row,
+    depth90Row,
+    averageNowcastValue: averageNowcastValue,
   }
 }


### PR DESCRIPTION
This PR fixes the display of the average nowcast value. We had previously mistaken the `type_id` 4 of the nowcast data for the average value. This has gone unnoticed because the production database includes only dummy values for the nowcast at the moment. Therefore we didn't get suspicious when the value of `type_id` didn't match with the actual average that would have resulted from the calculation of `type_id`'s 1, 2, and 3.

We fix this by calculating the average value in the `mapRowsToDepths` helper. It may not be the perfect place naming-wise, but as of now the place where it makes the most sense without having to do bigger refactorings.