### PR TITLE
feat: display nowcast from yesterday on map (and update forecast viz)

### DIFF
--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -19,7 +19,7 @@ import { ForecastViz } from '@components/ForecastViz'
 import { FeedbackRequestsList } from '@components/FeedbackRequestsList'
 import csrf from '@lib/api/csrf'
 import { useForecastData } from '@lib/hooks/useForecastData'
-import { combineNowAndForecastData } from '@lib/utils/forecastUtil/forecastUtil'
+import { mapForecastDataToMinimum } from '@lib/utils/forecastUtil/forecastUtil'
 import { useTreeRainAmount } from '@lib/hooks/useTreeRainAmount'
 import { useTreeData } from '@lib/hooks/useTreeData'
 import { mapRawQueryToState } from '@lib/utils/queryUtil'
@@ -141,7 +141,7 @@ const TreePage: TreePageWithLayout = ({ treeId, csrfToken }) => {
   const forecastReady = nowcastData
   const forecast =
     nowcastReady && forecastReady
-      ? combineNowAndForecastData(Object.values(nowcastData), forecastData)
+      ? mapForecastDataToMinimum(forecastData)
       : undefined
 
   return (

--- a/src/components/ForecastViz/ForecastViz.test.tsx
+++ b/src/components/ForecastViz/ForecastViz.test.tsx
@@ -11,8 +11,10 @@ import commoDE from '../../../locales/de/common.json'
 
 const NOW = new Date('2022-08-24T11:17:56.022Z')
 
-const getDateLabel = (date: Date, today: Date): string => {
-  return `${format(date, 'dd.MM.')}${isSameDay(date, today) ? ' (Heute)' : ''}`
+const getDateLabel = (date: Date, tomorrow: Date): string => {
+  return `${format(date, 'dd.MM.')}${
+    isSameDay(date, tomorrow) ? ' (Morgen)' : ''
+  }`
 }
 
 interface DataItem {
@@ -20,7 +22,7 @@ interface DataItem {
   date: Date
 }
 
-const fakeData: DataItem[] = Array.from(Array(15)).map((_, i) => {
+const fakeData: DataItem[] = Array.from(Array(13)).map((_, i) => {
   return {
     date: addDays(NOW, i),
     waterSupplyStatusId:
@@ -29,24 +31,24 @@ const fakeData: DataItem[] = Array.from(Array(15)).map((_, i) => {
 })
 
 describe('ForecastViz', () => {
-  test('should render 15 days without data', () => {
+  test('should render 13 days without data', () => {
     render(
       <I18nProvider lang={'de'} namespaces={{ common: commoDE }}>
-        <ForecastViz today={NOW} />
+        <ForecastViz startDate={NOW} />
       </I18nProvider>
     )
 
-    Array.from(Array(15)).forEach((_, i) => {
+    Array.from(Array(13)).forEach((_, i) => {
       const dateInXDays = getDateLabel(addDays(NOW, i), NOW)
       const labelInXDays = screen.getByLabelText(`${dateInXDays}: Unbekannt`)
       expect(labelInXDays).toBeInTheDocument()
     })
   })
 
-  test('should render 15 days with all data', () => {
+  test('should render 13 days with all data', () => {
     render(
       <I18nProvider lang={'de'} namespaces={{ common: commoDE }}>
-        <ForecastViz today={NOW} data={fakeData} />
+        <ForecastViz startDate={NOW} data={fakeData} />
       </I18nProvider>
     )
 
@@ -59,10 +61,10 @@ describe('ForecastViz', () => {
     })
   })
 
-  test('should render 15 days with some data', () => {
+  test('should render 13 days with some data', () => {
     render(
       <I18nProvider lang={'de'} namespaces={{ common: commoDE }}>
-        <ForecastViz today={NOW} data={fakeData.filter((_, i) => i % 2)} />
+        <ForecastViz startDate={NOW} data={fakeData.filter((_, i) => i % 2)} />
       </I18nProvider>
     )
 
@@ -79,11 +81,11 @@ describe('ForecastViz', () => {
     })
   })
 
-  test('should render 15 days with data out of 14 days range', () => {
+  test('should render 13 days with data out of 14 days range', () => {
     render(
       <I18nProvider lang={'de'} namespaces={{ common: commoDE }}>
         <ForecastViz
-          today={NOW}
+          startDate={NOW}
           data={fakeData.map((item) => ({
             ...item,
             date: addDays(item.date, 60),
@@ -92,7 +94,7 @@ describe('ForecastViz', () => {
       </I18nProvider>
     )
 
-    Array.from(Array(15)).forEach((_, i) => {
+    Array.from(Array(13)).forEach((_, i) => {
       const dateInXDays = getDateLabel(addDays(NOW, i), NOW)
       const labelInXDays = screen.getByLabelText(`${dateInXDays}: Unbekannt`)
       expect(labelInXDays).toBeInTheDocument()

--- a/src/components/TreesMap/treesLayer.ts
+++ b/src/components/TreesMap/treesLayer.ts
@@ -1,5 +1,5 @@
 import { WATER_SUPPLY_STATUSES } from '@lib/utils/mapSuctionTensionToStatus'
-import { startOfDay } from 'date-fns'
+import { startOfYesterday } from 'date-fns'
 import { LayerSpecification, SourceSpecification } from 'maplibre-gl'
 import colors from '../../style/colors'
 
@@ -53,7 +53,7 @@ const getColorScale = (idSuffix = ''): (string | number)[] => {
 const IS_OUTDATED_NOWCAST = [
   '<=',
   ['get', 'nowcast_timestamp_stamm'],
-  startOfDay(Date.now()).toISOString(),
+  startOfYesterday().toISOString(),
 ]
 
 export const TREES_LAYER: LayerSpecification = {

--- a/src/lib/requests/getForecastData.ts
+++ b/src/lib/requests/getForecastData.ts
@@ -1,5 +1,5 @@
 import { getBaseUrl } from '@lib/utils/urlUtil'
-import { startOfDay } from 'date-fns'
+import { startOfYesterday } from 'date-fns'
 
 /**
  * According to the database schema all values except id are nullable.
@@ -28,8 +28,8 @@ const TYPE_ID_COLUMN_NAME = 'type_id'
 const TYPE_ID_FOR_AVERAGE = '4'
 
 const TIMESTAMP_COLUMN = 'timestamp'
-const TODAY = startOfDay(Date.now()).toISOString()
-const FORECAST_MAX_ROWS = 14
+const TODAY = startOfYesterday().toISOString()
+const FORECAST_MAX_ROWS = 13
 
 /**
  * Fetches the forecast data for a tree (maximum 14 days).
@@ -50,7 +50,7 @@ export const getForecastData = async (
     [TIMESTAMP_COLUMN]: `gte.${TODAY}`,
     order: `${TIMESTAMP_COLUMN}`,
     limit: `${FORECAST_MAX_ROWS}`,
-    offset: '0',
+    offset: '1',
   })
 
   const response = await fetch(`${REQUEST_URL}?${REQUEST_PARAMS.toString()}`, {

--- a/src/lib/requests/getNowcastData.ts
+++ b/src/lib/requests/getNowcastData.ts
@@ -1,5 +1,5 @@
 import { getBaseUrl } from '@lib/utils/urlUtil'
-import { startOfDay } from 'date-fns'
+import { startOfYesterday } from 'date-fns'
 
 /**
  * According to the database schema all values except id are nullable.
@@ -26,7 +26,7 @@ export type NowcastDataType = {
 const TABLE_NAME = 'nowcast'
 const TREE_ID_COLUMN_NAME = 'tree_id'
 const TIMESTAMP_COLUMN = 'timestamp'
-const START_OF_TODAY = startOfDay(Date.now()).toISOString()
+const START_OF_YESTERDAY = startOfYesterday().toISOString()
 
 /**
  * Fetches the most recent nowcast data for a tree.
@@ -43,7 +43,7 @@ export const getNowcastData = async (
 
   const REQUEST_PARAMS = new URLSearchParams({
     [TREE_ID_COLUMN_NAME]: `eq.${treeId}`,
-    [TIMESTAMP_COLUMN]: `gte.${START_OF_TODAY}`,
+    [TIMESTAMP_COLUMN]: `gte.${START_OF_YESTERDAY}`,
     limit: '4',
     offset: '0',
   })

--- a/src/lib/requests/getNowcastData.ts
+++ b/src/lib/requests/getNowcastData.ts
@@ -13,7 +13,8 @@ export type NowcastDataType = {
   /** 1 = value for 30cm depth.
    *  2 = value for 60cm depth.
    *  3 = value for 90cm depth.
-   *  4 = value for average.
+   *  4 = value for Mittelwert.
+   *  5 = value for Stamm.
    */
   type_id?: number
   timestamp?: string

--- a/src/lib/utils/forecastUtil/forecastUtil.ts
+++ b/src/lib/utils/forecastUtil/forecastUtil.ts
@@ -5,12 +5,12 @@ import {
   WaterSupplyStatusType,
 } from '../mapSuctionTensionToStatus'
 
-interface CombinedNowAndForecastType {
+interface MapForecastDataToMinimumType {
   date: Date
   waterSupplyStatusId: WaterSupplyStatusType['id'] | undefined
 }
 
-interface nowAndForecastMinimumType {
+interface ForecastMinimumType {
   timestamp: string
   value: number
 }
@@ -21,19 +21,17 @@ const hasTimestampAndValue = (item?: NowcastDataType): boolean =>
 const mapFilteredData = ({
   timestamp,
   value,
-}: nowAndForecastMinimumType): CombinedNowAndForecastType => ({
+}: ForecastMinimumType): MapForecastDataToMinimumType => ({
   date: new Date(timestamp),
   waterSupplyStatusId: mapSuctionTensionToStatus(value)?.id,
 })
 
-export const combineNowAndForecastData = (
-  nowcastData: NowcastDataType[],
+export const mapForecastDataToMinimum = (
   forecastData: ForecastDataType[]
-): CombinedNowAndForecastType[] => {
-  const nowcastAvg = nowcastData.find(({ type_id }) => type_id === 4)
-  const combinedData = [nowcastAvg, ...forecastData]
+): MapForecastDataToMinimumType[] => {
+  const combinedData = [...forecastData]
   const filteredData = combinedData.filter(
     hasTimestampAndValue
-  ) as nowAndForecastMinimumType[]
+  ) as ForecastMinimumType[]
   return filteredData.map(mapFilteredData)
 }


### PR DESCRIPTION
**Attention: Visually, this is a breaking change! We now have nowcast values for all Straßenbäume, therefore all of them are colored. We don't have a feature yet for distinguishing between Mitte/Neukölln and the remaining districts.**

![Screenshot 2023-07-17 at 11 11 24](https://github.com/technologiestiftung/baumblick-frontend/assets/15640196/3083db99-0b5d-4cc4-960e-35c2a96ab37d)

**Context**:
The most recent nowcast value is actually always the value fron one day ago. Therefore we need to adjust the outdated filter. Also, while the `type_id` for average remains 4, the naming has not been changed yet because because it would require some refactoring, including in the vector tiles generator.