### PR TITLE
feat: inform users about purpose of messages

### DIFF
--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -171,6 +171,8 @@
     "reportButton": "{{title}} melden",
     "proximityWord": "Nähe",
     "modalHelp": "Bitte bestätige, dass du beim Baum <bold>„{{treeName}}“</bold> {{address}} die Eigenschaft <bold>„{{title}}“</bold> erkannt hast.",
+    "modalDisclaimer": "Meldungen in Baumblick werden innerhalb des Förderprojektes QTrees auf ihren Nutzen getestet. Um eine Meldung an das zuständige Ordnungsamt zu senden, nutze <0>dieses offizielle Formular</0>.",
+    "modalDisclaimerAriaLabel": "Formular zur Meldung beim Ordnungsamt",
     "modalConfirm": "Melden",
     "modalCancel": "Abbrechen",
     "confirmationTitle": "Danke! Erfolgreich gemeldet!",

--- a/src/components/FeedbackReportModal/ModalDescription.tsx
+++ b/src/components/FeedbackReportModal/ModalDescription.tsx
@@ -2,6 +2,7 @@ import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { FC } from 'react'
 import { FeedbackReportModalPropType } from './FeedbackReportModal'
+import classNames from 'classnames'
 
 export const ModalDescription: FC<
   Pick<FeedbackReportModalPropType, 'title' | 'address' | 'treeName'>
@@ -13,16 +14,49 @@ export const ModalDescription: FC<
   }
 
   return (
-    <Trans
-      i18nKey="common:feedback.modalHelp"
-      components={formattingComponents}
-      values={{
-        address: address
-          ? `${t('feedback.proximityWord')} <bold>${address}</bold>`
-          : '',
-        title,
-        treeName,
-      }}
-    />
+    <>
+      <div>
+        <Trans
+          i18nKey="common:feedback.modalHelp"
+          components={formattingComponents}
+          values={{
+            address: address
+              ? `${t('feedback.proximityWord')} <bold>${address}</bold>`
+              : '',
+            title,
+            treeName,
+          }}
+        />
+      </div>
+      <div
+        className={classNames(
+          'mt-3',
+          'text-xs font-medium font-sans',
+          'border p-2'
+        )}
+      >
+        <Trans
+          i18nKey="common:feedback.modalDisclaimer"
+          components={[
+            // Anchor does have content, provided by our locale file.
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a
+              key="link"
+              className={classNames(
+                'px-0.5',
+                'underline',
+                'transition-colors focus:outline-none',
+                'focus:ring-2 focus:ring-gray-600',
+                'hover:text-gray-500'
+              )}
+              href="https://ordnungsamt.berlin.de/frontend/meldungNeu/wo"
+              aria-label={t('common:feedback.modalDisclaimerAriaLabel')}
+              target="_blank"
+              rel="noopener noreferrer"
+            />,
+          ]}
+        />
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
This PR adds a disclaimer to the user messages modal. This way users know that their message is not forwarded to official instances.

![Screenshot 2023-07-17 at 15 28 12](https://github.com/technologiestiftung/baumblick-frontend/assets/15640196/df223362-cc81-41f7-a81d-43a72ef47793)
